### PR TITLE
Add Totals component

### DIFF
--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -10,6 +10,7 @@ import GridRow from 'components/alexandria/GridRowComponent';
 import React from 'react';
 import Search from 'components/alexandria/SearchComponent';
 import Slicey from 'components/alexandria/SliceyComponent';
+import Totals from 'components/alexandria/TotalsComponent';
 import TreePickerNode from 'components/alexandria/TreePickerNodeComponent';
 
 const defaultBreadcrumbNodes = [
@@ -50,6 +51,14 @@ class AppComponent extends React.Component {
 
     return (
       <div className="index">
+
+        <h1>Totals</h1>
+        <Totals
+            toSum={[
+              { label: 'Movies Category - Medium Rectangle', value: 1000 },
+              { label: 'Selected', value: 36.80 },
+            ]}
+        />
 
         <h1>TreePickerNode</h1>
         <div className="grid-component">

--- a/src/components/alexandria/AlertComponent.js
+++ b/src/components/alexandria/AlertComponent.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 require('styles/alexandria/Alert.scss');
 
@@ -11,7 +11,7 @@ const AlertComponent = ({ type, children }) => (
 AlertComponent.displayName = 'AlexandriaAlertComponent';
 
 AlertComponent.propTypes = {
-  type: React.PropTypes.oneOf(['success', 'info', 'warning', 'danger']),
+  type: PropTypes.oneOf(['success', 'info', 'warning', 'danger']),
 };
 AlertComponent.defaultProps = {
   type: 'info',

--- a/src/components/alexandria/BreadcrumbComponent.js
+++ b/src/components/alexandria/BreadcrumbComponent.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 require('styles/alexandria/Breadcrumb.scss');
 
@@ -37,13 +37,13 @@ const BreadcrumbComponent = ({ nodes, onClick }) => {
 BreadcrumbComponent.displayName = 'AlexandriaBreadcrumbComponent';
 
 BreadcrumbComponent.propTypes = {
-  nodes: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      id: React.PropTypes.string.isRequired,
-      label: React.PropTypes.string.isRequired,
+  nodes: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
     })
   ),
-  onClick: React.PropTypes.func,
+  onClick: PropTypes.func,
 };
 BreadcrumbComponent.defaultProps = {
   nodes: [],

--- a/src/components/alexandria/EmptyComponent.js
+++ b/src/components/alexandria/EmptyComponent.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 require('styles/alexandria/Empty.scss');
 
@@ -19,9 +19,9 @@ const EmptyComponent = ({ collection, icon, text }) => {
 EmptyComponent.displayName = 'AlexandriaEmptyComponent';
 
 EmptyComponent.propTypes = {
-  collection: React.PropTypes.any,
-  icon: React.PropTypes.string,
-  text: React.PropTypes.string,
+  collection: PropTypes.any,
+  icon: PropTypes.string,
+  text: PropTypes.string,
 };
 EmptyComponent.defaultProps = {
   collection: null,

--- a/src/components/alexandria/GridCellComponent.js
+++ b/src/components/alexandria/GridCellComponent.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 import classSuffixHelper from '../../helpers/classSuffixHelper';
 
@@ -22,8 +22,8 @@ const GridCellComponent = ({ classSuffixes, stretch, children }) => {
 GridCellComponent.displayName = 'AlexandriaGridCellComponent';
 
 GridCellComponent.propTypes = {
-  classSuffixes: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
-  stretch: React.PropTypes.bool.isRequired,
+  classSuffixes: PropTypes.arrayOf(PropTypes.string).isRequired,
+  stretch: PropTypes.bool.isRequired,
 };
 
 GridCellComponent.defaultProps = {

--- a/src/components/alexandria/GridRowComponent.js
+++ b/src/components/alexandria/GridRowComponent.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 import classSuffixHelper from '../../helpers/classSuffixHelper';
 
@@ -22,10 +22,10 @@ const GridRowComponent = ({ horizontalBorder, short, type, verticalCellBorder, c
 GridRowComponent.displayName = 'AlexandriaGridRowComponent';
 
 GridRowComponent.propTypes = {
-  horizontalBorder: React.PropTypes.bool.isRequired,
-  short: React.PropTypes.bool.isRequired,
-  type: React.PropTypes.oneOf(['body', 'header', 'subfooter', 'footer']).isRequired,
-  verticalCellBorder: React.PropTypes.bool.isRequired,
+  horizontalBorder: PropTypes.bool.isRequired,
+  short: PropTypes.bool.isRequired,
+  type: PropTypes.oneOf(['body', 'header', 'subfooter', 'footer']).isRequired,
+  verticalCellBorder: PropTypes.bool.isRequired,
 };
 
 GridRowComponent.defaultProps = {

--- a/src/components/alexandria/SearchComponent.js
+++ b/src/components/alexandria/SearchComponent.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 require('styles/alexandria/Search.scss');
 
@@ -43,9 +43,9 @@ class SearchComponent extends React.Component {
 }
 
 SearchComponent.propTypes = {
-  onQuery: React.PropTypes.func,
-  placeholder: React.PropTypes.string,
-  throttleTime: React.PropTypes.number,
+  onQuery: PropTypes.func,
+  placeholder: PropTypes.string,
+  throttleTime: PropTypes.number,
 };
 
 SearchComponent.defaultProps = {

--- a/src/components/alexandria/SliceyComponent.js
+++ b/src/components/alexandria/SliceyComponent.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import Arc from 'components/alexandria/slicey/ArcComponent';
 import Donut from 'components/alexandria/slicey/DonutComponent';
 import Marker from 'components/alexandria/slicey/MarkerComponent';
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { ROUND, HALF, QUARTER, getPointX, getPointY } from 'components/alexandria/slicey/dataProcessor';
 
 require('styles/alexandria/Slicey.scss');
@@ -73,15 +73,15 @@ const SliceyComponent = ({ dataset, diameter, donut, marker }) => {
 SliceyComponent.displayName = 'AlexandriaSliceyComponent';
 
 SliceyComponent.propTypes = {
-  dataset: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      label: React.PropTypes.string.isRequired,
-      value: React.PropTypes.number.isRequired,
+  dataset: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.number.isRequired,
     })
   ),
-  diameter: React.PropTypes.number,
-  donut: React.PropTypes.bool,
-  marker: React.PropTypes.number,
+  diameter: PropTypes.number,
+  donut: PropTypes.bool,
+  marker: PropTypes.number,
 };
 
 SliceyComponent.defaultProps = {

--- a/src/components/alexandria/TotalsComponent.js
+++ b/src/components/alexandria/TotalsComponent.js
@@ -2,7 +2,7 @@ import _ from 'lodash';
 import Grid from 'components/alexandria/GridComponent';
 import GridCell from 'components/alexandria/GridCellComponent';
 import GridRow from 'components/alexandria/GridRowComponent';
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 const TotalsComponent = ({ toSum, valueFormatter }) => (
   <Grid>
@@ -22,13 +22,13 @@ const TotalsComponent = ({ toSum, valueFormatter }) => (
 TotalsComponent.displayName = 'AlexandriaTotalsComponent';
 
 TotalsComponent.propTypes = {
-  toSum: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      label: React.PropTypes.string.isRequired,
-      value: React.PropTypes.number.isRequired,
+  toSum: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.string.isRequired,
+      value: PropTypes.number.isRequired,
     })
   ).isRequired,
-  valueFormatter: React.PropTypes.func.isRequired,
+  valueFormatter: PropTypes.func.isRequired,
 };
 
 TotalsComponent.defaultProps = {

--- a/src/components/alexandria/TotalsComponent.js
+++ b/src/components/alexandria/TotalsComponent.js
@@ -1,0 +1,39 @@
+import _ from 'lodash';
+import Grid from 'components/alexandria/GridComponent';
+import GridCell from 'components/alexandria/GridCellComponent';
+import GridRow from 'components/alexandria/GridRowComponent';
+import React from 'react';
+
+const TotalsComponent = ({ toSum, valueFormatter }) => (
+  <Grid>
+    {toSum.map(({ label, value }, index) =>
+      <GridRow short horizontalBorder={false} key={index}>
+        <GridCell stretch>{label}</GridCell>
+        <GridCell>{valueFormatter(value)}</GridCell>
+      </GridRow>
+    )}
+    <GridRow short horizontalBorder={false} type="footer">
+      <GridCell stretch>Total</GridCell>
+      <GridCell>{valueFormatter(_.sum(toSum, 'value'))}</GridCell>
+    </GridRow>
+  </Grid>
+);
+
+TotalsComponent.displayName = 'AlexandriaTotalsComponent';
+
+TotalsComponent.propTypes = {
+  toSum: React.PropTypes.arrayOf(
+    React.PropTypes.shape({
+      label: React.PropTypes.string.isRequired,
+      value: React.PropTypes.number.isRequired,
+    })
+  ).isRequired,
+  valueFormatter: React.PropTypes.func.isRequired,
+};
+
+TotalsComponent.defaultProps = {
+  toSum: [],
+  valueFormatter: (value) => value,
+};
+
+export default TotalsComponent;

--- a/src/components/alexandria/TreePickerNodeComponent.js
+++ b/src/components/alexandria/TreePickerNodeComponent.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 require('styles/alexandria/TreePickerNode.scss');
 
@@ -39,21 +39,21 @@ const TreePickerNodeComponent = ({ buttonFirst, currencyFilter, includeNode, nod
 
 TreePickerNodeComponent.displayName = 'AlexandriaTreePickerNodeComponent';
 
-const nodePropType = React.PropTypes.shape({
-  id: React.PropTypes.number.isRequired,
-  label: React.PropTypes.string.isRequired,
-  type: React.PropTypes.string.isRequired,
-  cost: React.PropTypes.number.isRequired,
-  path: React.PropTypes.arrayOf(React.PropTypes.string.isRequired).isRequired,
+const nodePropType = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  label: PropTypes.string.isRequired,
+  type: PropTypes.string.isRequired,
+  cost: PropTypes.number.isRequired,
+  path: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
 });
 
 TreePickerNodeComponent.propTypes = {
-  buttonFirst: React.PropTypes.bool.isRequired,
-  currencyFilter: React.PropTypes.func.isRequired,
-  includeNode: React.PropTypes.func.isRequired,
+  buttonFirst: PropTypes.bool.isRequired,
+  currencyFilter: PropTypes.func.isRequired,
+  includeNode: PropTypes.func.isRequired,
   node: nodePropType.isRequired,
-  removeNode: React.PropTypes.func.isRequired,
-  selectedNodes: React.PropTypes.arrayOf(nodePropType).isRequired,
+  removeNode: PropTypes.func.isRequired,
+  selectedNodes: PropTypes.arrayOf(nodePropType).isRequired,
 };
 
 TreePickerNodeComponent.defaultProps = {

--- a/src/components/alexandria/slicey/ArcComponent.js
+++ b/src/components/alexandria/slicey/ArcComponent.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 require('styles/alexandria/slicey/Arc.scss');
 
@@ -17,14 +17,14 @@ const ArcComponent = ({ data }) => {
 ArcComponent.displayName = 'AlexandriaSliceyArcComponent';
 
 ArcComponent.propTypes = {
-  data: React.PropTypes.shape({
-    label: React.PropTypes.string.isRequired,
-    id: React.PropTypes.number.isRequired,
-    largeArcFlag: React.PropTypes.number.isRequired,
-    x1: React.PropTypes.number.isRequired,
-    y1: React.PropTypes.number.isRequired,
-    x2: React.PropTypes.number.isRequired,
-    y2: React.PropTypes.number.isRequired,
+  data: PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    id: PropTypes.number.isRequired,
+    largeArcFlag: PropTypes.number.isRequired,
+    x1: PropTypes.number.isRequired,
+    y1: PropTypes.number.isRequired,
+    x2: PropTypes.number.isRequired,
+    y2: PropTypes.number.isRequired,
   }),
 };
 

--- a/src/components/alexandria/slicey/MarkerComponent.js
+++ b/src/components/alexandria/slicey/MarkerComponent.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 
 import { ROUND, QUARTER, getPointX, getPointY } from './dataProcessor';
 
@@ -18,7 +18,7 @@ const MarkerComponent = ({ fraction }) => {
 MarkerComponent.displayName = 'AlexandriaSliceyMarkerComponent';
 
 MarkerComponent.propTypes = {
-  fraction: React.PropTypes.number,
+  fraction: PropTypes.number,
 };
 MarkerComponent.defaultProps = {
   fraction: 0,

--- a/test/components/alexandria/TotalsComponentTest.js
+++ b/test/components/alexandria/TotalsComponentTest.js
@@ -1,0 +1,73 @@
+/* eslint-env node, mocha */
+/* global expect */
+
+import createComponent from 'helpers/shallowRenderHelper';
+import TotalsComponent from 'components/alexandria/TotalsComponent';
+
+describe('TotalsComponent', () => {
+  const toSumRowsIndex = 0;
+  const totalsRowIndex = 1;
+
+  it('should render with defaults', () => {
+    const component = createComponent(TotalsComponent);
+    expect(component.type.name).to.equal('GridComponent');
+    expect(component.props.children).to.have.length(2);
+
+    expect(component.props.children[toSumRowsIndex]).to.deep.equal([]);
+
+    const totalRow = component.props.children[totalsRowIndex];
+    expect(totalRow.type.name).to.equal('GridRowComponent');
+    expect(totalRow.props.short).to.equal(true);
+    expect(totalRow.props.horizontalBorder).to.equal(false);
+    expect(totalRow.props.type).to.equal('footer');
+
+    expect(totalRow.props.children[0].props.stretch).to.equal(true);
+    expect(totalRow.props.children[0].props.children).to.equal('Total');
+
+    expect(totalRow.props.children[1].props.children).to.equal(0);
+  });
+
+  it('should render with props', () => {
+    const component = createComponent(TotalsComponent, {
+      toSum: [
+        { label: 'Custom Paint for Yo Whip', value: 200000 },
+        { label: 'Selected', value: 50000 },
+      ],
+      valueFormatter: (value) => `€${(value / 100).toFixed(2)}`,
+    });
+    expect(component.type.name).to.equal('GridComponent');
+    expect(component.props.children).to.have.length(2);
+    const rows = component.props.children[toSumRowsIndex];
+
+    const firstRow = rows[0];
+    expect(firstRow.type.name).to.equal('GridRowComponent');
+    expect(firstRow.props.short).to.equal(true);
+    expect(firstRow.props.horizontalBorder).to.equal(false);
+
+    expect(firstRow.props.children[0].props.stretch).to.equal(true);
+    expect(firstRow.props.children[0].props.children).to.equal('Custom Paint for Yo Whip');
+
+    expect(firstRow.props.children[1].props.children).to.equal('€2000.00');
+
+    const secondRow = rows[1];
+    expect(secondRow.type.name).to.equal('GridRowComponent');
+    expect(secondRow.props.short).to.equal(true);
+    expect(secondRow.props.horizontalBorder).to.equal(false);
+
+    expect(secondRow.props.children[0].props.stretch).to.equal(true);
+    expect(secondRow.props.children[0].props.children).to.equal('Selected');
+
+    expect(secondRow.props.children[1].props.children).to.equal('€500.00');
+
+    const totalRow = component.props.children[totalsRowIndex];
+    expect(totalRow.type.name).to.equal('GridRowComponent');
+    expect(totalRow.props.short).to.equal(true);
+    expect(totalRow.props.horizontalBorder).to.equal(false);
+    expect(totalRow.props.type).to.equal('footer');
+
+    expect(totalRow.props.children[0].props.stretch).to.equal(true);
+    expect(totalRow.props.children[0].props.children).to.equal('Total');
+
+    expect(totalRow.props.children[1].props.children).to.equal('€2500.00');
+  });
+});


### PR DESCRIPTION
#### What does this PR accomplish?
Add Totals component
Destructure PropTypes from React as noted in CR comments on this PR.

#### How should this be manually tested?
- [x] Test in one browser, no custom css in this one.

#### Any background context you want to provide?
Uses some of the grid features from the previous PR.

#### What are the relevant trello cards?
https://trello.com/c/fBRG3lIC/4757-alexandria-treepicker-totals

#### Screenshots (if appropriate)
![screen shot 2015-12-09 at 4 33 23 pm](https://cloud.githubusercontent.com/assets/4197647/11677568/399ad470-9e93-11e5-802d-e88aab17287a.png)