### PR TITLE
Add Treepicker Selected Component

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -56,7 +56,7 @@ rules:
   hex-notation: 2
   indentation: 2
   leading-zero: 2
-  nesting-depth: 2
+  nesting-depth: [2, max-depth: 3]
   property-sort-order: 2
   quotes: 2
   shorthand-values: 2

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -12,6 +12,7 @@ import Search from 'components/alexandria/SearchComponent';
 import Slicey from 'components/alexandria/SliceyComponent';
 import Totals from 'components/alexandria/TotalsComponent';
 import TreePickerNode from 'components/alexandria/TreePickerNodeComponent';
+import TreePickerSelected from 'components/alexandria/TreePickerSelectedComponent';
 
 const defaultBreadcrumbNodes = [
   { id: 'aaa-111', label: 'Australia' },
@@ -43,11 +44,26 @@ class AppComponent extends React.Component {
   }
 
   render() {
-    const sliceyTestData = [
+    const sliceyDataset = [
       { label: 'positive', value: 50 },
       { label: 'negative', value: 25 },
       { label: 'info', value: 35 },
     ];
+
+    const rootTypes = [
+      {
+        label: 'Geography',
+        id: 0,
+        icon: 'http://placehold.it/16x16',
+        emptyIcon: 'http://placehold.it/70x70',
+        isRequired: true,
+      },
+    ];
+
+    const selectedNodesByRootType = _.groupBy([
+      { id: 0, label: 'Australian Capital Territory', type: 'State', path: ['AU'], value: 1000, rootTypeId: 0 },
+      { id: 1, label: 'Northern Territory', type: 'State', path: ['AU'], value: 500, rootTypeId: 0 },
+    ], 'rootTypeId');
 
     return (
       <div className="index">
@@ -60,9 +76,15 @@ class AppComponent extends React.Component {
             ]}
         />
 
+        <h1>TreePickerSelected</h1>
+        <TreePickerSelected
+            rootTypes={rootTypes}
+            selectedNodesByRootType={selectedNodesByRootType}
+        />
+
         <h1>TreePickerNode</h1>
         <Grid>
-          <TreePickerNode node={{ id: 1, label: 'Melbourne', type: 'City', cost: 900, path: ['AU', 'VIC'] }} />
+          <TreePickerNode node={{ id: 1, label: 'Melbourne', type: 'City', value: 900, path: ['AU', 'VIC'] }} />
         </Grid>
 
         <h1>Empty</h1>
@@ -78,7 +100,7 @@ class AppComponent extends React.Component {
         <Search placeholder="your memories" onQuery={this.searchOnQuery.bind(this)} throttleTime={200} />
 
         <h1>Slicey</h1>
-        <Slicey dataset={sliceyTestData} diameter={150} marker={0.2} donut />
+        <Slicey dataset={sliceyDataset} diameter={150} marker={0.2} donut />
 
         <h1>Grid</h1>
         <Grid>

--- a/src/components/alexandria/EmptyComponent.js
+++ b/src/components/alexandria/EmptyComponent.js
@@ -13,7 +13,7 @@ const EmptyComponent = ({ collection, icon, text }) => {
     );
   }
 
-  return <div className="empty-component" />;
+  return <div />;
 };
 
 EmptyComponent.displayName = 'AlexandriaEmptyComponent';

--- a/src/components/alexandria/TreePickerNodeComponent.js
+++ b/src/components/alexandria/TreePickerNodeComponent.js
@@ -31,7 +31,7 @@ const TreePickerNodeComponent = ({ buttonFirst, valueFormatter, includeNode, nod
           <span className="treepickernode-component-metadata"> ({node.type} in {pathElement})</span>
         </GridCell>
         <GridCell>
-          {valueFormatter(node.cost)}
+          {valueFormatter(node.value)}
         </GridCell>
         {(buttonFirst) ? null : buttonElement}
       </GridRow>
@@ -45,7 +45,7 @@ const nodePropType = PropTypes.shape({
   id: PropTypes.number.isRequired,
   label: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
-  cost: PropTypes.number.isRequired,
+  value: PropTypes.number.isRequired,
   path: PropTypes.arrayOf(PropTypes.string.isRequired).isRequired,
 });
 

--- a/src/components/alexandria/TreePickerSelectedComponent.js
+++ b/src/components/alexandria/TreePickerSelectedComponent.js
@@ -1,0 +1,134 @@
+import _ from 'lodash';
+import Alert from 'components/alexandria/AlertComponent';
+import Empty from 'components/alexandria/EmptyComponent';
+import Grid from 'components/alexandria/GridComponent';
+import GridCell from 'components/alexandria/GridCellComponent';
+import GridRow from 'components/alexandria/GridRowComponent';
+import Totals from 'components/alexandria/TotalsComponent';
+import TreePickerNode from 'components/alexandria/TreePickerNodeComponent';
+import React, { PropTypes } from 'react';
+
+require('styles/alexandria/TreePickerSelected.scss');
+
+const SelectedComponent = ({
+  baseItem,
+  emptyIcon,
+  includeNode,
+  removeNode,
+  rootTypes,
+  selectedNodesByRootType,
+  valueFormatter,
+  valueLabel,
+  warnOnRequired,
+}) => {
+  const averagesByRootType = _(rootTypes)
+    .indexBy('id')
+    .mapValues(({ id }) => {
+      const selectedInRootType = _.get(selectedNodesByRootType, id);
+      if (_.isEmpty(selectedInRootType)) return 0;
+
+      return _.sum(selectedInRootType, 'value') / selectedInRootType.length;
+    })
+    .value();
+
+  const totalOfAverages = _.sum(averagesByRootType);
+
+  const unresolvedRootTypes = _(rootTypes)
+    .filter(({ id, isRequired }) => isRequired && _.isEmpty(selectedNodesByRootType[id]))
+    .pluck('label')
+    .join(', ');
+
+  const getRootTypeLabel = (rootTypeId) => {
+    const rootTypeMatchingId = _.find(rootTypes, { id: +rootTypeId });
+    if (rootTypeMatchingId) return rootTypeMatchingId.label;
+
+    throw new Error(`TreePickerSelectedComponent requires a rootType for id ${rootTypeId}`);
+  };
+
+  return (
+  <div className="treepickerselected-component">
+    <h1 className="treepickerselected-component-header">Selected</h1>
+    <Totals
+        toSum={[
+          { label: baseItem.label, value: baseItem.value },
+          { label: 'Selected', value: totalOfAverages },
+        ]}
+        valueFormatter={valueFormatter} />
+
+    {_.keys(selectedNodesByRootType).map((rootTypeId) =>
+      <Grid key={rootTypeId}>
+
+        <GridRow type="header">
+          <GridCell stretch>{getRootTypeLabel(rootTypeId)}</GridCell>
+          <GridCell>{valueLabel}</GridCell>
+        </GridRow>
+
+        {selectedNodesByRootType[rootTypeId].map((node) =>
+          <TreePickerNode
+              buttonFirst
+              valueFormatter={valueFormatter}
+              includeNode={includeNode.bind()}
+              key={node.id}
+              node={node}
+              removeNode={removeNode.bind()}
+              selectedNodes={selectedNodesByRootType[rootTypeId]} />
+        )}
+
+        <GridRow type="subfooter">
+          <GridCell stretch />
+          <GridCell>Average</GridCell>
+          <GridCell>{valueFormatter(averagesByRootType[rootTypeId])}</GridCell>
+        </GridRow>
+
+      </Grid>
+    )}
+    <Empty collection={_.values(selectedNodesByRootType)} icon={emptyIcon} text="Nothing Selected" />
+
+    {(unresolvedRootTypes) ?
+      <Alert type={warnOnRequired ? 'warning' : 'danger'}>{unresolvedRootTypes} are required.</Alert> :
+      null
+    }
+  </div>
+  );
+};
+
+SelectedComponent.displayName = 'AlexandriaTreePickerSelectedComponent';
+
+const rootType = PropTypes.shape({
+  emptyIcon: PropTypes.string,
+  icon: PropTypes.string.isRequired,
+  id: PropTypes.number.isRequired,
+  isRequired: PropTypes.bool.isRequired,
+  label: PropTypes.string.isRequired,
+});
+
+SelectedComponent.propTypes = {
+  baseItem: PropTypes.shape({
+    label: PropTypes.string.isRequired,
+    value: PropTypes.number.isRequired,
+  }).isRequired,
+  emptyIcon: PropTypes.string,
+  includeNode: PropTypes.func.isRequired,
+  removeNode: PropTypes.func.isRequired,
+  rootTypes: PropTypes.arrayOf(rootType).isRequired,
+  selectedNodesByRootType: PropTypes.shape().isRequired,
+  valueFormatter: PropTypes.func.isRequired,
+  valueLabel: PropTypes.string.isRequired,
+  warnOnRequired: PropTypes.bool.isRequired,
+};
+
+SelectedComponent.defaultProps = {
+  baseItem: {
+    label: 'Base',
+    value: 0,
+  },
+  includeNode: () => null,
+  removeNode: () => null,
+  rootTypes: [],
+  selectedNodesByRootType: {},
+  valueFormatter: (value) => value,
+  valueLabel: 'Cost',
+  warnOnRequired: false,
+};
+
+export default SelectedComponent;

--- a/src/styles/alexandria/Empty.scss
+++ b/src/styles/alexandria/Empty.scss
@@ -2,8 +2,11 @@
 @import '../fontSize';
 
 .empty-component {
-  margin: 60px auto;
+  cursor: default;
+  margin: 0 auto;
+  padding: 60px;
   text-align: center;
+  user-select: none;
 
   &-icon {
     $icon-diameter: 70px;

--- a/src/styles/alexandria/Grid.scss
+++ b/src/styles/alexandria/Grid.scss
@@ -17,12 +17,10 @@
   &-row-vertical-cell-border {
     .grid-component-cell {
       border-right: $border-lighter;
-    }
-  }
 
-  &-cell {
-    &:last-child {
-      border-right: 0;
+      &:last-child {
+        border-right: 0;
+      }
     }
   }
 

--- a/src/styles/alexandria/GridRow.scss
+++ b/src/styles/alexandria/GridRow.scss
@@ -13,6 +13,12 @@
   &-subfooter {
     background-color: $color-gray-white;
     color: $color-text-light;
+
+    .grid-component-cell {
+      &:last-child {
+        color: $color-text;
+      }
+    }
   }
 
   &-footer {
@@ -29,12 +35,5 @@
   &-horizontal-border,
   &:last-child {
     border-bottom-color: $color-border-lighter;
-  }
-}
-
-// Override &-subfooter color.
-.grid-component-cell {
-  &:last-child {
-    color: $color-text;
   }
 }

--- a/src/styles/alexandria/TreePickerNode.scss
+++ b/src/styles/alexandria/TreePickerNode.scss
@@ -9,6 +9,7 @@
   }
 
   .grid-component-cell-button {
+    height: 15px;
     min-width: 60px;
   }
 }

--- a/src/styles/alexandria/TreePickerSelected.scss
+++ b/src/styles/alexandria/TreePickerSelected.scss
@@ -1,0 +1,16 @@
+@import '../fontSize';
+@import '../border';
+
+.treepickerselected-component {
+
+  &-header {
+    font-size: $font-size-subheader;
+    line-height: 41px;
+    margin: 0;
+  }
+
+  .empty-component {
+    border-left: $border-lighter;
+    border-right: $border-lighter;
+  }
+}

--- a/test/components/alexandria/EmptyComponentTest.js
+++ b/test/components/alexandria/EmptyComponentTest.js
@@ -18,15 +18,15 @@ describe('EmptyComponent', () => {
     expect(textElement.props.children).to.equal('Nothing to show.');
   });
 
-  it('should render without contents when passed a non-empty collection Array', () => {
+  it('should render an empty div when passed a non-empty collection Array', () => {
     const component = createComponent(EmptyComponent, { collection: [1] });
-    expect(component.props.className).to.equal('empty-component');
+    expect(component.props.className).to.be.an('undefined');
     expect(component.props.children).to.be.an('undefined');
   });
 
-  it('should render without contents when passed a non-empty collection Object', () => {
+  it('should render an empty div when passed a non-empty collection Object', () => {
     const component = createComponent(EmptyComponent, { collection: { foo: 1 } });
-    expect(component.props.className).to.equal('empty-component');
+    expect(component.props.className).to.be.an('undefined');
     expect(component.props.children).to.be.an('undefined');
   });
 

--- a/test/components/alexandria/TreePickerNodeComponentTest.js
+++ b/test/components/alexandria/TreePickerNodeComponentTest.js
@@ -10,7 +10,7 @@ describe('TreePickerNodeComponent', () => {
     id: 1,
     label: 'New York',
     type: 'City',
-    cost: 200,
+    value: 200,
     path: ['USA', 'NY'],
   };
 
@@ -42,9 +42,9 @@ describe('TreePickerNodeComponent', () => {
     expect(pathElement.props.children).to.equal('NY, USA');
     expect(metaDataElement.props.children[4]).to.equal(')');
 
-    const costCellElement = rowElement.props.children[2];
-    expect(costCellElement.type.name).to.equal('GridCellComponent');
-    expect(costCellElement.props.children).to.equal(200);
+    const valueCellElement = rowElement.props.children[2];
+    expect(valueCellElement.type.name).to.equal('GridCellComponent');
+    expect(valueCellElement.props.children).to.equal(200);
 
     const buttonLastCellElement = rowElement.props.children[3];
     expect(buttonLastCellElement.type.name).to.equal('GridCellComponent');
@@ -72,14 +72,14 @@ describe('TreePickerNodeComponent', () => {
     expect(buttonLastCellElement).to.be.a('null');
   });
 
-  it('should filter cost when provided', () => {
+  it('should filter value when provided', () => {
     const valueFormatter = (value) => `€${value / 100}`;
     const component = createComponent(TreePickerNodeComponent, { node: newYorkNode, valueFormatter });
     const rowElement = component.props.children;
 
-    const costCellElement = rowElement.props.children[2];
-    expect(costCellElement.type.name).to.equal('GridCellComponent');
-    expect(costCellElement.props.children).to.equal('€2');
+    const valueCellElement = rowElement.props.children[2];
+    expect(valueCellElement.type.name).to.equal('GridCellComponent');
+    expect(valueCellElement.props.children).to.equal('€2');
   });
 
   it('should fire includeNode when clicking on the `include` button', () => {
@@ -110,7 +110,7 @@ describe('TreePickerNodeComponent', () => {
       id: 3,
       label: 'Cameroon',
       type: 'Country',
-      cost: 400,
+      value: 400,
       path: [],
     };
     const component = createComponent(TreePickerNodeComponent, { node });
@@ -131,9 +131,9 @@ describe('TreePickerNodeComponent', () => {
     const pathElement = metaDataElement.props.children[3];
     expect(pathElement).to.be.a('null');
 
-    const costCellElement = rowElement.props.children[2];
-    expect(costCellElement.type.name).to.equal('GridCellComponent');
-    expect(costCellElement.props.children).to.equal(400);
+    const valueCellElement = rowElement.props.children[2];
+    expect(valueCellElement.type.name).to.equal('GridCellComponent');
+    expect(valueCellElement.props.children).to.equal(400);
   });
 
   it('should fire removeNode when clicking on the `remove` button', () => {

--- a/test/components/alexandria/TreePickerSelectedComponentTest.js
+++ b/test/components/alexandria/TreePickerSelectedComponentTest.js
@@ -1,0 +1,163 @@
+/* eslint-env node, mocha */
+/* global expect */
+
+import _ from 'lodash';
+import createComponent from 'helpers/shallowRenderHelper';
+import TreePickerSelected from 'components/alexandria/TreePickerSelectedComponent';
+
+describe('TreePickerSelectedComponent', () => {
+  const rootTypes = [
+    {
+      label: 'Geography',
+      id: 0,
+      icon: 'http://placehold.it/16x16',
+      emptyIcon: 'http://placehold.it/70x70',
+      isRequired: true,
+    },
+    { label: 'Audiences', id: 1, icon: 'http://placehold.it/16x16', isRequired: false },
+    { label: 'Segments', id: 2, icon: 'http://placehold.it/16x16', isRequired: true },
+  ];
+
+  const actNode =
+    { id: 0, label: 'Australian Capital Territory', type: 'State', path: ['AU'], value: 1000, rootTypeId: 0 };
+
+  const ntNode =
+  { id: 1, label: 'Northern Territory', type: 'State', path: ['AU'], value: 500, rootTypeId: 0 };
+
+  const selectedNodesByRootType = _.groupBy([actNode, ntNode], 'rootTypeId');
+
+  const checkHeader = (component) => {
+    const headerElement = component.props.children[0];
+    expect(headerElement.type).to.equal('h1');
+    expect(headerElement.props.className).to.equal('treepickerselected-component-header');
+    expect(headerElement.props.children).to.equal('Selected');
+  };
+
+  it('should render with defaults', () => {
+    const component = createComponent(TreePickerSelected);
+    expect(component.props.className).to.equal('treepickerselected-component');
+
+    checkHeader(component);
+
+    const totalsElement = component.props.children[1];
+    expect(totalsElement.type.name).to.equal('TotalsComponent');
+    expect(totalsElement.props.toSum).to.deep.equal([
+      { label: 'Base', value: 0 },
+      { label: 'Selected', value: 0 },
+    ]);
+    expect(totalsElement.props.valueFormatter).to.be.a('function');
+
+    const gridElements = component.props.children[2];
+    expect((gridElements)).to.have.length(0);
+
+    const emptyElement = component.props.children[3];
+    expect(emptyElement.type.name).to.equal('EmptyComponent');
+    expect(emptyElement.props.collection).to.have.length(0);
+    expect(emptyElement.props.icon).to.equal('//placehold.it/70x70');
+    expect(emptyElement.props.text).to.equal('Nothing Selected');
+
+    const alertElement = component.props.children[4];
+    expect(alertElement).to.be.a('null');
+  });
+
+  it('should render with props', () => {
+    const component = createComponent(TreePickerSelected, {
+      rootTypes,
+      selectedNodesByRootType,
+      emptyIcon: 'awesome-url',
+      valueLabel: 'Galactic Credits',
+    });
+    expect(component.props.className).to.equal('treepickerselected-component');
+
+    checkHeader(component);
+
+    const totalsElement = component.props.children[1];
+    expect(totalsElement.type.name).to.equal('TotalsComponent');
+    expect(totalsElement.props.toSum).to.deep.equal([
+      { label: 'Base', value: 0 },
+      { label: 'Selected', value: 750 },
+    ]);
+    expect(totalsElement.props.valueFormatter).to.be.a('function');
+
+    const gridElements = component.props.children[2];
+    expect(gridElements).to.have.length(1);
+
+    const gridElement = gridElements[0];
+    expect(gridElement.type.name).to.equal('GridComponent');
+
+    const headerRowElement = gridElement.props.children[0];
+    expect(headerRowElement.type.name).to.equal('GridRowComponent');
+    expect(headerRowElement.props.type).to.equal('header');
+
+    const headerFirstCell = headerRowElement.props.children[0];
+    expect(headerFirstCell.type.name).to.equal('GridCellComponent');
+    expect(headerFirstCell.props.stretch).to.equal(true);
+    expect(headerFirstCell.props.children).to.equal('Geography');
+
+    const headerSecondCell = headerRowElement.props.children[1];
+    expect(headerSecondCell.type.name).to.equal('GridCellComponent');
+    expect(headerSecondCell.props.children).to.equal('Galactic Credits');
+
+    const nodeElements = gridElement.props.children[1];
+    expect(nodeElements).to.have.length(2);
+
+    expect(nodeElements[0].props.buttonFirst).to.equal(true);
+    expect(nodeElements[0].props.valueFormatter).to.be.a('function');
+    expect(nodeElements[0].props.includeNode).to.be.a('function');
+    expect(nodeElements[0].props.includeNode()).to.be.a('null');
+    expect(nodeElements[0].props.node).to.deep.equal(actNode);
+    expect(nodeElements[0].props.removeNode).to.be.a('function');
+    expect(nodeElements[0].props.removeNode()).to.be.a('null');
+    expect(nodeElements[0].props.selectedNodes).to.deep.equal(selectedNodesByRootType[0]);
+
+    expect(nodeElements[1].props.node).to.deep.equal(ntNode);
+
+    const subFooterRowElement = gridElement.props.children[2];
+    expect(subFooterRowElement.type.name).to.equal('GridRowComponent');
+    expect(subFooterRowElement.props.type).to.equal('subfooter');
+
+    const subFooterFirstCell = subFooterRowElement.props.children[0];
+    expect(subFooterFirstCell.type.name).to.equal('GridCellComponent');
+    expect(subFooterFirstCell.props.stretch).to.equal(true);
+    expect(subFooterFirstCell.props.children).to.be.an('undefined');
+
+    const subFooterSecondCell = subFooterRowElement.props.children[1];
+    expect(subFooterSecondCell.type.name).to.equal('GridCellComponent');
+    expect(subFooterSecondCell.props.children).to.equal('Average');
+
+    const subFooterThirdCell = subFooterRowElement.props.children[2];
+    expect(subFooterThirdCell.type.name).to.equal('GridCellComponent');
+    expect(subFooterThirdCell.props.children).to.equal(750);
+
+    const emptyElement = component.props.children[3];
+    expect(emptyElement.type.name).to.equal('EmptyComponent');
+    expect(emptyElement.props.collection).to.deep.equal([[actNode, ntNode]]);
+    expect(emptyElement.props.icon).to.equal('awesome-url');
+    expect(emptyElement.props.text).to.equal('Nothing Selected');
+
+    const alertElement = component.props.children[4];
+    expect(alertElement.type.name).to.equal('AlertComponent');
+    expect(alertElement.props.type).to.equal('danger');
+    expect(alertElement.props.children).to.deep.equal(['Segments', ' are required.']);
+  });
+
+  it('should render alert as warning when warnOnRequired is true', () => {
+    const component = createComponent(TreePickerSelected, {
+      rootTypes,
+      selectedNodesByRootType,
+      warnOnRequired: true,
+    });
+    expect(component.props.className).to.equal('treepickerselected-component');
+
+    const alertElement = component.props.children[4];
+    expect(alertElement.type.name).to.equal('AlertComponent');
+    expect(alertElement.props.type).to.equal('warning');
+    expect(alertElement.props.children).to.deep.equal(['Segments', ' are required.']);
+  });
+
+  it('should error when there is a selectedNode with no corresponding rootType', () => {
+    expect(() => {
+      createComponent(TreePickerSelected, { selectedNodesByRootType });
+    }).to.throw('TreePickerSelectedComponent requires a rootType for id 0');
+  });
+});


### PR DESCRIPTION
- Increase allowed SCSS nesting by 1 because it was impossible to use
  pseudo-selectors in a clean way when nesting-depth is 2.
- Change cost in the node component to value to keep naming consistent.
- Clean up slightly weird SCSS caused by the over restrictive
  nesting limit.
- Optimise the Empty component so that users can't select the text,
  and so that it doesn't take up space when not rendering.

https://trello.com/c/jU5BKghT/4738-alexandria-tree-picker-selected-right-pane-component-2d
![screen shot 2015-12-11 at 3 23 33 pm](https://cloud.githubusercontent.com/assets/4197647/11735920/30f8b7e0-a01b-11e5-857e-29c97ee59dff.png)
