### PR TITLE
Build: Remove custom jsx-indent-props in .eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,6 @@
     "max-len": [1, 120, 2],
     "no-cond-assign": [2, "except-parens"],
     "quote-props": 0,
-    "react/jsx-indent-props": [2, 4],
     "react/jsx-no-bind": 0
   }
 }

--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -70,16 +70,16 @@ class AppComponent extends React.Component {
 
         <h1>Totals</h1>
         <Totals
-            toSum={[
-              { label: 'Movies Category - Medium Rectangle', value: 1000 },
-              { label: 'Selected', value: 36.80 },
-            ]}
+          toSum={[
+            { label: 'Movies Category - Medium Rectangle', value: 1000 },
+            { label: 'Selected', value: 36.80 },
+          ]}
         />
 
         <h1>TreePickerSelected</h1>
         <TreePickerSelected
-            rootTypes={rootTypes}
-            selectedNodesByRootType={selectedNodesByRootType}
+          rootTypes={rootTypes}
+          selectedNodesByRootType={selectedNodesByRootType}
         />
 
         <h1>TreePickerNode</h1>

--- a/src/components/alexandria/SearchComponent.js
+++ b/src/components/alexandria/SearchComponent.js
@@ -26,16 +26,16 @@ class SearchComponent extends React.Component {
     return (
       <div className="search-component">
         <input
-            className="search-component-input"
-            name="search"
-            onChange={this.changeValue.bind(this)}
-            placeholder={`Search ${this.props.placeholder}`}
-            type="search"
-            value={value}
+          className="search-component-input"
+          name="search"
+          onChange={this.changeValue.bind(this)}
+          placeholder={`Search ${this.props.placeholder}`}
+          type="search"
+          value={value}
         />
         <div
-            className={`search-component-icon${_.isEmpty(value) ? ' is-empty' : ''}`}
-            onClick={this.clearValue.bind(this)}
+          className={`search-component-icon${_.isEmpty(value) ? ' is-empty' : ''}`}
+          onClick={this.clearValue.bind(this)}
         />
       </div>
     );

--- a/src/components/alexandria/TreePickerSelectedComponent.js
+++ b/src/components/alexandria/TreePickerSelectedComponent.js
@@ -49,11 +49,11 @@ const SelectedComponent = ({
   <div className="treepickerselected-component">
     <h1 className="treepickerselected-component-header">Selected</h1>
     <Totals
-        toSum={[
-          { label: baseItem.label, value: baseItem.value },
-          { label: 'Selected', value: totalOfAverages },
-        ]}
-        valueFormatter={valueFormatter}
+      toSum={[
+        { label: baseItem.label, value: baseItem.value },
+        { label: 'Selected', value: totalOfAverages },
+      ]}
+      valueFormatter={valueFormatter}
     />
 
     {_.keys(selectedNodesByRootType).map((rootTypeId) =>
@@ -66,13 +66,13 @@ const SelectedComponent = ({
 
         {selectedNodesByRootType[rootTypeId].map((node) =>
           <TreePickerNode
-              buttonFirst
-              valueFormatter={valueFormatter}
-              includeNode={includeNode.bind()}
-              key={node.id}
-              node={node}
-              removeNode={removeNode.bind()}
-              selectedNodes={selectedNodesByRootType[rootTypeId]}
+            buttonFirst
+            valueFormatter={valueFormatter}
+            includeNode={includeNode.bind()}
+            key={node.id}
+            node={node}
+            removeNode={removeNode.bind()}
+            selectedNodes={selectedNodesByRootType[rootTypeId]}
           />
         )}
 


### PR DESCRIPTION
- Indenting twice isn't necessary in JSX as it is in Jade
  because it is obvious when the tag closes (`/>` or `</foo>`).