### PR TITLE
Build: Add publishConfig to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "release:minor": "npm version minor && npm publish && git push --follow-tags",
     "release:patch": "npm version patch && npm publish && git push --follow-tags"
   },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "keywords": [
     "UI Library",
     "components"


### PR DESCRIPTION
- Stops us from accidentally publishing to our internal npm server.