### PR TITLE
Build: Replace deprecated autoprefixer-loader

### DIFF
--- a/cfg/base.js
+++ b/cfg/base.js
@@ -4,25 +4,14 @@ const host = '0.0.0.0';
 const port = 8000;
 const srcPath = path.join(__dirname, '/../src');
 const publicPath = '/assets/';
-const supportedBrowsers = [
-  'last 2 versions',
-  '> 5%',
-  'ie >= 8',
-  'not and_chr > 0',
-  'not and_uc > 0',
-  'not android > 0',
-  'not ie_mob > 0',
-  'not ios_saf > 0',
-  'not op_mini > 0',
-].join('", "');
-const autoprefixerConfig = `autoprefixer-loader?{browsers:["${supportedBrowsers}"]}`;
+const autoprefixer = require('autoprefixer');
 
 module.exports = {
   debug: true,
   output: {
     path: path.join(__dirname, '/../dist/assets'),
     filename: 'app.js',
-    publicPath: publicPath,
+    publicPath,
   },
   devServer: {
     contentBase: './src/',
@@ -31,13 +20,28 @@ module.exports = {
     hot: true,
     port,
     publicPath,
-    noInfo: false,
+    noInfo: true,
   },
+  postcss: () => [
+    autoprefixer({
+      browsers: [
+        'last 2 versions',
+        '> 5%',
+        'ie >= 8',
+        'not and_chr > 0',
+        'not and_uc > 0',
+        'not android > 0',
+        'not ie_mob > 0',
+        'not ios_saf > 0',
+        'not op_mini > 0',
+      ],
+    }),
+  ],
   resolve: {
     extensions: ['', '.js', '.jsx'],
     alias: {
-      components: srcPath + '/components/',
-      styles: srcPath + '/styles/',
+      components: `${srcPath}/components/`,
+      styles: `${srcPath}/styles/`,
     },
   },
   module: {
@@ -55,7 +59,7 @@ module.exports = {
       },
       {
         test: /\.scss/,
-        loader: `style-loader!css-loader!${autoprefixerConfig}!sass-loader?outputStyle=expanded`,
+        loader: 'style-loader!css-loader!postcss-loader!sass-loader?outputStyle=expanded',
       },
       {
         test: /\.(png|jpg|gif|woff|woff2)$/,

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   ],
   "author": "Adslot",
   "devDependencies": {
-    "autoprefixer-loader": "^3.2.0",
+    "autoprefixer": "^6.3.4",
     "babel-core": "^6.5.2",
     "babel-eslint": "^5.0.0",
     "babel-loader": "^6.2.2",
@@ -72,6 +72,7 @@
     "object-assign": "^4.0.1",
     "open": "^0.0.5",
     "phantomjs-prebuilt": "^2.1.4",
+    "postcss-loader": "^0.8.2",
     "react-addons-test-utils": "^0.14.7",
     "react-hot-loader": "^1.3.0",
     "rimraf": "^2.5.2",


### PR DESCRIPTION
- Also: Silence chunk info when running `npm start`