### PR TITLE
Fix: Dependency, travis, pre-commit fixes and validation with node v4/v6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 
 node_js:
-  - "5"
+  - "6"
+  - "4"
 
 after_success:
 - npm run codecov

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -5,29 +5,29 @@ module.exports = function configureKarma(config) {
     basePath: '',
     browsers: ['PhantomJS'],
     files: [
-      'test/loadtests.js',
+      'test/loadtests.js'
     ],
     port: 8080,
     captureTimeout: 60000,
     frameworks: ['phantomjs-shim', 'mocha', 'chai'],
     client: {
-      mocha: {},
+      mocha: {}
     },
     singleRun: true,
     reporters: ['coverage', 'mocha'],
     preprocessors: {
-      'test/loadtests.js': ['webpack'],
+      'test/loadtests.js': ['webpack']
     },
     coverageReporter: {
       dir: 'coverage/',
       reporters: [
         { type: 'lcov', subdir: '.' },
-        { type: 'json', subdir: '.' },
-      ],
+        { type: 'json', subdir: '.' }
+      ]
     },
     webpack: webpackCfg,
     webpackServer: {
-      noInfo: true,
-    },
+      noInfo: true
+    }
   });
 };

--- a/package.json
+++ b/package.json
@@ -10,23 +10,23 @@
   },
   "main": "dist/alexandria-main.js",
   "scripts": {
+    "check-commit": "node scripts/commit-msg",
+    "clean": "rimraf dist/*",
+    "codecov": "cat coverage/coverage-final.json | codecov",
+    "dist": "webpack --bail --env=dist",
+    "jscs-lint": "jscs ./src ./test",
+    "jscs-fix": "jscs ./src ./test --fix",
+    "lint": "eslint ./src --rulesdir ./src && eslint ./test --rulesdir ./test",
+    "posttest": "npm run lint && npm run sass-lint && npm run jscs-lint && npm run check-commit",
+    "profile": "webpack --env=dist --profile --json > stats.json",
+    "release:major": "npm version major && npm publish && git push --follow-tags",
+    "release:minor": "npm version minor && npm publish && git push --follow-tags",
+    "release:patch": "npm version patch && npm publish && git push --follow-tags",
+    "sass-lint": "sass-lint './src/**/*.scss' -v",
     "start": "node server.js --env=dev",
     "start:cold": "node server.js --env=dev-cold",
     "test": "karma start",
-    "test:watch": "karma start --autoWatch=true --singleRun=false",
-    "codecov": "cat coverage/coverage-final.json | codecov",
-    "posttest": "npm run lint && npm run sass-lint && npm run jscs-lint && npm run check-commit",
-    "dist": "webpack --bail --env=dist",
-    "profile": "webpack --env=dist --profile --json > stats.json",
-    "lint": "eslint ./src --rulesdir ./src && eslint ./test --rulesdir ./test",
-    "sass-lint": "sass-lint './src/**/*.scss' -v",
-    "jscs-lint": "jscs ./src ./test",
-    "jscs-fix": "jscs ./src ./test --fix",
-    "clean": "rimraf dist/*",
-    "check-commit": "./scripts/commit-msg",
-    "release:major": "npm version major && npm publish && git push --follow-tags",
-    "release:minor": "npm version minor && npm publish && git push --follow-tags",
-    "release:patch": "npm version patch && npm publish && git push --follow-tags"
+    "test:watch": "karma start --autoWatch=true --singleRun=false"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
@@ -93,5 +93,8 @@
     "react": "^15.0.2",
     "react-dom": "^15.0.2",
     "svg4everybody": "^2.0.3"
+  },
+  "engines": {
+    "node": "^4.4"
   }
 }

--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -24,6 +24,11 @@ then
 fi
 
 
+# Run linting and commit check.
+echo "  - linting"
+npm run posttest
+
+
 # Compile the distribution from source.
 echo "  - compiling distribution files;"
 npm run -s dist && git add dist/*


### PR DESCRIPTION
- Set nodejs version to be tested against in travis to be v4 and v6
- Reordered run scripts alphabetically in `package.json`
- Set nodejs engine in use
- Updated pre-commit script to do linting
- Fixed `check-commit` to run with `node` to ensure it works on Windows OS as well