### PR TITLE
Fix: Add .gitattributes to set LF endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf


### PR DESCRIPTION
Set `.gitattributes` so that LF endings are used on git clone for Windows, jscs linting fails otherwise