### PR TITLE
Update: svg circle to set the inverse property

### DIFF
--- a/src/components/Main.js
+++ b/src/components/Main.js
@@ -225,6 +225,7 @@ class AppComponent extends React.Component {
 
         <SvgSymbolCircle classSuffixes={['70']} />
         <SvgSymbolCircle href="/assets/svg-symbols.svg#checklist-incomplete" />
+        <SvgSymbolCircle classSuffixes={['70', 'inverse']} />
 
         <h1>Totals</h1>
         <Grid>

--- a/src/styles/alexandria/SvgSymbolCircle.scss
+++ b/src/styles/alexandria/SvgSymbolCircle.scss
@@ -18,6 +18,10 @@
   height: $svg-icon-size;
   width: $svg-icon-size;
 
+  &-inverse {
+    background-color: $color-inverse;
+  }
+
   .svg-symbol-component {
     @include svg-size($svg-icon-size);
   }


### PR DESCRIPTION
This will give the facility to have the inverse property with the svg circle icons.

![screen shot 2016-07-01 at 10 41 04 am](https://cloud.githubusercontent.com/assets/7802760/16508659/7c97090c-3f78-11e6-8e23-ca9de2d27768.png)
