### PR TITLE
Fix: Tag component styles

### DIFF
--- a/src/styles/alexandria/Tag.scss
+++ b/src/styles/alexandria/Tag.scss
@@ -37,7 +37,9 @@
   }
 
   &-accent {
-    font-weight: $font-weight-bold;
+    label {
+      font-weight: $font-weight-bold;
+    }
   }
 
   .action-button {
@@ -57,6 +59,7 @@
   }
 
   label {
+    margin-bottom: 0;
     max-width: 105px; // Fits ~18 characters
     overflow: hidden;
     text-overflow: ellipsis;


### PR DESCRIPTION
#### Changes
- Target more specific selector for accent label so font weight is correct
- Add margin-bottom: 0 to label to override direct-web styles