### PR TITLE
Fix: Fix search clear button

### DIFF
--- a/src/components/alexandria/SvgSymbolComponent.jsx
+++ b/src/components/alexandria/SvgSymbolComponent.jsx
@@ -5,13 +5,13 @@ import classSuffixHelper from '../../helpers/classSuffixHelper';
 require('styles/alexandria/SvgSymbol.scss');
 
 const SvgSymbolComponent = (props) => {
-  const { classSuffixes, href } = props;
+  const { classSuffixes, href, onClick } = props;
   const componentClass = 'svg-symbol-component';
   const suffixOptions = { clickable: props.onClick };
   const classesList = classSuffixHelper({ classSuffixes, suffixOptions, componentClass });
 
   return (
-    <svg className={`${componentClass}${classesList}`}>
+    <svg className={`${componentClass}${classesList}`} onClick={onClick}>
       <use xlinkHref={href} />
     </svg>
   );

--- a/src/styles/alexandria/SvgSymbolCircle.scss
+++ b/src/styles/alexandria/SvgSymbolCircle.scss
@@ -11,7 +11,7 @@
     width: $inner-diameter;
   }
 
-  background-color: $color-gray-lighter;
+  background-color: $color-gray-lightest;
   border-radius: $border-radius-circle;
   display: inline-block;
 


### PR DESCRIPTION
This will fixed to search component clear button issue. 

will make svg circle background color to lighter grey

https://trello.com/c/V6EGh5Qc/5602-briefing-cannot-clear-publisher-search
