### PR TITLE
Fix: Empty text style fix

### DIFF
--- a/src/styles/alexandria/Empty.scss
+++ b/src/styles/alexandria/Empty.scss
@@ -14,5 +14,6 @@
     font-size: $font-size-body;
     line-height: $line-height-etalon;
     margin-top: $spacing-etalon / 3;
+    white-space: pre-wrap;
   }
 }


### PR DESCRIPTION
#### Changes
- Add white-space: pre-wrap to empty text so that new line formatting is maintained

#### Screenshots:
e.g. `SimpleTreePickerPure` component:

![screen shot 2016-09-23 at 5 25 36 pm](https://cloud.githubusercontent.com/assets/5505611/18777568/290e114a-81b3-11e6-9921-041796fa36d8.png)
