### PR TITLE
adjust spinner "small" and "medium" size to fit in a button

### DIFF
--- a/src/styles/alexandria/Spinner.scss
+++ b/src/styles/alexandria/Spinner.scss
@@ -16,12 +16,14 @@
       border-width: 2px;
       height: $font-size-body;
       width: $font-size-body;
+      height: 16px;
+      width: 16px;
     }
 
     &-medium {
       border-width: 3px;
-      height: 30px;
-      width: 30px;
+      height: 24px;
+      width: 24px;
     }
 
     &-large {

--- a/src/styles/alexandria/Spinner.scss
+++ b/src/styles/alexandria/Spinner.scss
@@ -1,6 +1,7 @@
 @import '../color';
 @import '../font-weight';
 @import '../font-size';
+@import '../variables';
 
 .spinner-component {
   $color-spinner-light: $color-gray-light;
@@ -14,10 +15,8 @@
 
     &-small {
       border-width: 2px;
-      height: $font-size-body;
-      width: $font-size-body;
-      height: 16px;
-      width: 16px;
+      height: $svg-icon-size;
+      width: $svg-icon-size;
     }
 
     &-medium {


### PR DESCRIPTION
![screen shot 2016-12-12 at 1 20 45 pm](https://cloud.githubusercontent.com/assets/13200207/21086278/2c2effe2-c06f-11e6-8260-27f2f8e79f1c.png)
Change to make "small" Spinner fit normal size Button and  "medium" fit a large one. This is for the SpinnerButton component in adslot-ui.