### PR TITLE
Fix: Broken spinner button imports

### DIFF
--- a/scripts/git-hooks/pre-commit
+++ b/scripts/git-hooks/pre-commit
@@ -12,8 +12,8 @@ then
     echo "👾  Installing node modules."
     npm install
     echo "📑  Compiling distribution files for release."
-    npm run -s dist && git add dist/*
-    exit 0
+    npm run -s dist && git add dist/* && exit 0
+    exit 1
   fi
 fi
 

--- a/src/styles/alexandria/Spinner.scss
+++ b/src/styles/alexandria/Spinner.scss
@@ -1,7 +1,7 @@
 @import '../color';
 @import '../font-weight';
 @import '../font-size';
-@import '../variables';
+@import '../variable';
 
 .spinner-component {
   $color-spinner-light: $color-gray-light;


### PR DESCRIPTION
SASS-Lint doesn't pick up any broken or missing import paths
NPM release assume dist is generated correctly

- Fix code.
- Fix release to fail correctly if dist fails.