### PR TITLE
Update: svg circle to support size 50

### DIFF
--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -242,7 +242,7 @@ class AppComponent extends React.Component {
 
         <h1>SvgSymbolCircle</h1>
 
-        <SvgSymbolCircle href="/assets/svg-symbols.svg#checklist-incomplete" classSuffixes={['70']} />
+        <SvgSymbolCircle href="/assets/svg-symbols.svg#checklist-incomplete" classSuffixes={['50']} />
         <SvgSymbolCircle href="/assets/svg-symbols.svg#checklist-incomplete" />
         <SvgSymbolCircle href="/assets/svg-symbols.svg#checklist-incomplete" classSuffixes={['70', 'inverse']} />
 

--- a/src/styles/alexandria/SvgSymbolCircle.scss
+++ b/src/styles/alexandria/SvgSymbolCircle.scss
@@ -41,4 +41,5 @@
 
   // Sizes specified unitless in classSuffixes ['70']
   @include circle-size(70px);
+  @include circle-size(50px);
 }


### PR DESCRIPTION
update svg circle scss to support the size 50px

For some of the designs, in direct-web need the svg circle size to be smaller than the currently supporting size(70px)