### PR TITLE
tag content now can be set dynamically

### DIFF
--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -256,6 +256,14 @@ class AppComponent extends React.Component {
         <Tag actionIconSvgHref="/assets/svg-symbols.svg#cancel" accent="1">Custom Colour</Tag>
         <Tag actionIconSvgHref="/assets/svg-symbols.svg#cancel" inverse accent="1">Inverse Custom Colour</Tag>
         <Tag accent="2" onAction={_.noop} id="bar" actionIconSvgHref="/assets/svg-symbols.svg#cancel">Clearable</Tag>
+        <Tag accent="2" onAction={_.noop} id="bar" actionIconSvgHref="/assets/svg-symbols.svg#cancel">
+          <div style={{ width: '100px' }}>Column 1</div>
+          <div style={{ width: '100px' }}>Column 2</div>
+          <div style={{ width: '100px' }}>
+            Column 3
+            <p>multiline<br />content</p>
+          </div>
+        </Tag>
 
         <p>
           <label className="accent-0">Example</label>

--- a/src/components/alexandria/TagComponent.jsx
+++ b/src/components/alexandria/TagComponent.jsx
@@ -30,7 +30,7 @@ const TagComponent = ({ children, inverse, id, onAction, accent, actionIconSvgHr
 
   return (
     <span className={`${componentClass}${classes}`} data-test-selector={`tag-${id}`}>
-      <label title={children}>{children}</label>
+      {children}
       {onAction ? <ActionButton {...{ onAction, id, actionIconSvgHref }} /> : null}
     </span>
   );
@@ -39,7 +39,7 @@ const TagComponent = ({ children, inverse, id, onAction, accent, actionIconSvgHr
 TagComponent.displayName = 'AlexandriaTagComponent';
 
 TagComponent.propTypes = {
-  children: PropTypes.string.isRequired,
+  children: PropTypes.node.isRequired,
   id: PropTypes.string,
   accent: PropTypes.string,
   inverse: PropTypes.bool,

--- a/src/styles/alexandria/Tag.scss
+++ b/src/styles/alexandria/Tag.scss
@@ -18,8 +18,8 @@
   display: inline-flex;
   font-size: $font-size-body;
   font-weight: $font-weight-light;
-  height: $tag-height;
   margin-right: $tag-spacing-etalon;
+  min-height: $tag-height;
   padding: 0 $tag-spacing-etalon;
 
   &.tag-component-inverse { // explicit .tag-component to force override of `.accent-n` inverse bg/fill colours

--- a/test/components/alexandria/TagComponentTest.jsx
+++ b/test/components/alexandria/TagComponentTest.jsx
@@ -51,4 +51,12 @@ describe('TagComponent', () => {
     expect(onAction.calledWith('Bar')).to.equal(true);
     expect(component.find(SvgSymbol).prop('href')).to.equal('foo');
   });
+
+  it('should render children nodes', () => {
+    const component = shallow(<Tag onAction={_.noop} actionIconSvgHref="foo">
+      <div className="child" />
+      <div className="child" />
+    </Tag>);
+    expect(component.find('.child')).to.have.length(2);
+  });
 });


### PR DESCRIPTION
Enable TagComponent to display more complicated content, e.g.
![screen shot 2017-05-01 at 3 44 36 pm](https://cloud.githubusercontent.com/assets/2588669/25573077/25a9754c-2e85-11e7-90fc-c45dbb1a0ecb.png)

Updated Tag css that display as follow:
![screen shot 2017-05-01 at 4 42 01 pm](https://cloud.githubusercontent.com/assets/2588669/25573992/6fc24caa-2e8d-11e7-89b6-873b96e72bc4.png)
